### PR TITLE
Feature/signup page

### DIFF
--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -12,11 +12,17 @@ import styles from "./styles.module.css";
 import type { RootState } from "@/store/store";
 
 const userSchema = z.object({
+	name: z.string().min(1, "ニックネームは必須です"),
 	email: z
 		.string()
 		.min(1, { message: "メールアドレスは必須です" })
 		.email({ message: "メールアドレスの形式で入力してください" }),
-	password: z.string().min(8, { message: "8文字以上で入力してください" }),
+	password: z.string().min(8, { message: "8文字以上で入力してください" }).regex(/^[a-zA-Z0-9]+$/, {
+		message: '英大文字、英小文字、数字で入力してください',
+	}), passwordConfirmation: z.string().min(1, { message: "確認用パスワードを入力してください" })
+}).refine((data) => data.password === data.passwordConfirmation, {
+	message: 'パスワードが一致しません。入力し直してください。',
+	path: ['passwordConfirmation'],
 });
 
 export type UserData = z.infer<typeof userSchema>;
@@ -52,6 +58,21 @@ export default function SignupPage() {
 						<p className={styles.errorMessage}>{errorMessage}</p>
 					)}
 					<div className={styles.inputWrap}>
+						<label className={styles.label} htmlFor="name">
+							ニックネーム
+						</label>
+						<input
+							{...register("name")}
+							className={errors.name ? styles.inputError : styles.input}
+							type="text"
+						/>
+						{errors.name && (
+							<span className={styles.errorMessage}>
+								{errors.name.message}
+							</span>
+						)}
+					</div>
+					<div className={styles.inputWrap}>
 						<label className={styles.label} htmlFor="email">
 							メールアドレス
 						</label>
@@ -78,6 +99,19 @@ export default function SignupPage() {
 						{errors.password && (
 							<span className={styles.errorMessage}>
 								{errors.password.message}
+							</span>
+						)}
+
+						<label className={styles.label} htmlFor="passwordConfirmation">
+							パスワード確認
+						</label>
+						<input
+							{...register("passwordConfirmation")}
+							className={errors.passwordConfirmation ? styles.inputError : styles.input}
+							type="password" />
+						{errors.passwordConfirmation && (
+							<span className={styles.errorMessage}>
+								{errors.passwordConfirmation.message}
 							</span>
 						)}
 					</div>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -162,6 +162,13 @@ export default function SignupPage() {
 							accept=".jpg, .jpeg, .png"
 							onChange={handleChangeFile}
 						/>
+						{iconImg && (
+							<img
+								className={styles.viewImg}
+								src={iconImg}
+								alt="選択中のカバー写真"
+							/>
+						)}
 					</div>
 					<button className={styles.button}>新規登録する</button>
 				</form>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -14,7 +14,7 @@ import Compressor from 'compressorjs';
 import { useState } from 'react';
 
 const userSchema = z.object({
-	name: z.string().min(1, "ニックネームは必須です"),
+	userName: z.string().min(1, "ニックネームは必須です"),
 	email: z
 		.string()
 		.min(1, { message: "メールアドレスは必須です" })
@@ -77,8 +77,12 @@ export default function SignupPage() {
 	};
 
 	const onSubmit: SubmitHandler<UserData> = async (data) => {
+		const userInputData = {
+			...data,
+			iconImg
+		}
 		try {
-			await dispatch(signUpUser(data)).unwrap();
+			await dispatch(signUpUser(userInputData)).unwrap();
 			router.push("/albums");
 		} catch (error) {
 			console.error("SignUp failed:", error);
@@ -99,13 +103,13 @@ export default function SignupPage() {
 							ニックネーム
 						</label>
 						<input
-							{...register("name")}
-							className={errors.name ? styles.inputError : styles.input}
+							{...register("userName")}
+							className={errors.userName ? styles.inputError : styles.input}
 							type="text"
 						/>
-						{errors.name && (
+						{errors.userName && (
 							<span className={styles.errorMessage}>
-								{errors.name.message}
+								{errors.userName.message}
 							</span>
 						)}
 					</div>

--- a/app/signup/styles.module.css
+++ b/app/signup/styles.module.css
@@ -1,63 +1,68 @@
 .wrap {
-    height: calc(100vh - 65px);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background-color: rgba(0, 0, 0, 0.69);
+  height: calc(100vh - 65px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.69);
 }
 
 .signupForm {
-    width: 560px;
-    border-radius: 16px;
-    padding: 64px 120px;
-    background-color: #fff;
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+  width: 560px;
+  border-radius: 16px;
+  padding: 64px 120px;
+  background-color: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .inputWrap {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .label {
-    font-size: 12px;
-    color: #363636;
+  font-size: 12px;
+  color: #363636;
 }
 
 .input {
-    background-color: rgba(128, 128, 128, 0.21);
-    border-radius: 16px;
-    height: 48px;
-    padding: 0 12px;
-    outline-color: #111111;
+  background-color: rgba(128, 128, 128, 0.21);
+  border-radius: 16px;
+  height: 48px;
+  padding: 0 12px;
+  outline-color: #111111;
 }
 
 .inputError {
-    background-color: rgba(128, 128, 128, 0.21);
-    border-radius: 16px;
-    height: 48px;
-    padding: 0 12px;
-    outline-color: #ff4040;
+  background-color: rgba(128, 128, 128, 0.21);
+  border-radius: 16px;
+  height: 48px;
+  padding: 0 12px;
+  outline-color: #ff4040;
 }
 
 .title {
-    font-size: 36px;
-    font-weight: bold;
-    text-align: center;
+  font-size: 36px;
+  font-weight: bold;
+  text-align: center;
 }
 
 .button {
-    background-color: #111;
-    color: white;
-    border-radius: 16px;
-    padding: 8px 0;
-    height: 48px;
+  background-color: #111;
+  color: white;
+  border-radius: 16px;
+  padding: 8px 0;
+  height: 48px;
 }
 
 .errorMessage {
-    color: #ff4040;
-    font-size: 12px;
+  color: #ff4040;
+  font-size: 12px;
+}
+
+.viewImg {
+  height: 100px;
+  width: 100px;
 }

--- a/features/user/userSlice.ts
+++ b/features/user/userSlice.ts
@@ -1,49 +1,49 @@
 import { loginUser, signUpUser } from "@/services/userService";
-import type { User } from "@/types/type";
+import type { User, LoginUser } from "@/types/userTypes";
 import { createSlice } from "@reduxjs/toolkit";
 interface UserState {
-	data: User | null;
-	status: "idle" | "loading" | "succeeded" | "failed";
-	error: unknown | null;
+  data: User | LoginUser | null;
+  status: "idle" | "loading" | "succeeded" | "failed";
+  error: unknown | null;
 }
 
 const initialState: UserState = {
-	data: null,
-	status: "idle",
-	error: null,
+  data: null,
+  status: "idle",
+  error: null,
 };
 
 export const userSlice = createSlice({
-	name: "user",
-	initialState,
-	reducers: {},
-	extraReducers: (builder) => {
-		builder
-			.addCase(loginUser.pending, (state) => {
-				state.status = "loading";
-				state.error = null;
-			})
-			.addCase(loginUser.fulfilled, (state, action) => {
-				state.status = "succeeded";
-				state.data = action.payload;
-			})
-			.addCase(loginUser.rejected, (state, action) => {
-				state.status = "failed";
-				state.error = action.payload;
-			})
-			.addCase(signUpUser.pending, (state) => {
-				state.status = "loading";
-				state.error = null;
-			})
-			.addCase(signUpUser.fulfilled, (state, action) => {
-				state.status = "succeeded";
-				state.data = action.payload;
-			})
-			.addCase(signUpUser.rejected, (state, action) => {
-				state.status = "failed";
-				state.error = action.payload;
-			});
-	},
+  name: "user",
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(loginUser.pending, (state) => {
+        state.status = "loading";
+        state.error = null;
+      })
+      .addCase(loginUser.fulfilled, (state, action) => {
+        state.status = "succeeded";
+        state.data = action.payload;
+      })
+      .addCase(loginUser.rejected, (state, action) => {
+        state.status = "failed";
+        state.error = action.payload;
+      })
+      .addCase(signUpUser.pending, (state) => {
+        state.status = "loading";
+        state.error = null;
+      })
+      .addCase(signUpUser.fulfilled, (state, action) => {
+        state.status = "succeeded";
+        state.data = action.payload;
+      })
+      .addCase(signUpUser.rejected, (state, action) => {
+        state.status = "failed";
+        state.error = action.payload;
+      });
+  },
 });
 
 export default userSlice.reducer;

--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -1,15 +1,15 @@
 import { loginUser, signUpUser } from "@/services/userService";
 import type { AppDispatch, RootState } from "@/store/store";
-import type { UserInput } from "@/types/type";
+import type { NewUserInput, LoginUserInput } from "@/types/userTypes";
 import { useDispatch, useSelector } from "react-redux";
 
 export const useUser = () => {
-	const dispatch = useDispatch<AppDispatch>();
-	const user = useSelector((state: RootState) => state.user.data);
-	const status = useSelector((state: RootState) => state.user.status);
+  const dispatch = useDispatch<AppDispatch>();
+  const user = useSelector((state: RootState) => state.user.data);
+  const status = useSelector((state: RootState) => state.user.status);
 
-	const loginUserAction = (data: UserInput) => dispatch(loginUser(data));
-	const signUpUserAction = (data: UserInput) => dispatch(signUpUser(data));
+  const loginUserAction = (data: LoginUserInput) => dispatch(loginUser(data));
+  const signUpUserAction = (data: NewUserInput) => dispatch(signUpUser(data));
 
-	return { user, status, loginUserAction, signUpUserAction };
+  return { user, status, loginUserAction, signUpUserAction };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 				"@reduxjs/toolkit": "^2.2.6",
 				"autoprefixer": "10.4.17",
 				"axios": "^1.7.7",
+				"compressorjs": "^1.2.1",
 				"dayjs": "^1.11.13",
 				"firebase": "^11.1.0",
 				"framer-motion": "^11.2.11",
@@ -4341,6 +4342,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/blueimp-canvas-to-blob": {
+			"version": "3.29.0",
+			"resolved": "https://registry.npmjs.org/blueimp-canvas-to-blob/-/blueimp-canvas-to-blob-3.29.0.tgz",
+			"integrity": "sha512-0pcSSGxC0QxT+yVkivxIqW0Y4VlO2XSDPofBAqoJ1qJxgH9eiUDLv50Rixij2cDuEfx4M6DpD9UGZpRhT5Q8qg==",
+			"license": "MIT"
+		},
 		"node_modules/body-parser": {
 			"version": "1.20.2",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
@@ -4741,6 +4748,16 @@
 			"integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/compressorjs": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/compressorjs/-/compressorjs-1.2.1.tgz",
+			"integrity": "sha512-+geIjeRnPhQ+LLvvA7wxBQE5ddeLU7pJ3FsKFWirDw6veY3s9iLxAQEw7lXGHnhCJvBujEQWuNnGzZcvCvdkLQ==",
+			"license": "MIT",
+			"dependencies": {
+				"blueimp-canvas-to-blob": "^3.29.0",
+				"is-blob": "^2.1.0"
 			}
 		},
 		"node_modules/compute-scroll-into-view": {
@@ -5579,6 +5596,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-blob": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
+			"integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-core-module": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"@reduxjs/toolkit": "^2.2.6",
 		"autoprefixer": "10.4.17",
 		"axios": "^1.7.7",
+		"compressorjs": "^1.2.1",
 		"dayjs": "^1.11.13",
 		"firebase": "^11.1.0",
 		"framer-motion": "^11.2.11",

--- a/repositories/userRepository.ts
+++ b/repositories/userRepository.ts
@@ -1,7 +1,7 @@
 import { db, storage } from "@/lib/firebase";
 import { doc, setDoc } from "@firebase/firestore";
 import { auth } from "@/lib/firebase";
-import type { UserInput } from "@/types/userTypes";
+import type { NewUserInput, LoginUserInput } from "@/types/userTypes";
 import {
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
@@ -9,7 +9,7 @@ import {
 import { ref, uploadString, getDownloadURL } from "firebase/storage";
 
 export const userRepository = {
-  async signUpUser(userInputData: UserInput) {
+  async signUpUser(userInputData: NewUserInput) {
     try {
       const userCredential = await createUserWithEmailAndPassword(
         auth,
@@ -56,7 +56,7 @@ export const userRepository = {
     }
   },
 
-  async loginUser(data: UserInput) {
+  async loginUser(data: LoginUserInput) {
     try {
       const userCredential = await signInWithEmailAndPassword(
         auth,

--- a/repositories/userRepository.ts
+++ b/repositories/userRepository.ts
@@ -1,35 +1,72 @@
+import { db, storage } from "@/lib/firebase";
+import { doc, setDoc } from "@firebase/firestore";
 import { auth } from "@/lib/firebase";
-import type { UserInput } from "@/types/type";
+import type { UserInput } from "@/types/userTypes";
 import {
-	createUserWithEmailAndPassword,
-	signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
 } from "@firebase/auth";
+import { ref, uploadString, getDownloadURL } from "firebase/storage";
 
 export const userRepository = {
-	async signUpUser(data: UserInput) {
-		try {
-			const userCredential = await createUserWithEmailAndPassword(
-				auth,
-				data.email,
-				data.password,
-			);
-			return userCredential.user;
-		} catch (error) {
-			return Promise.reject(error);
-		}
-	},
+  async signUpUser(userInputData: UserInput) {
+    try {
+      const userCredential = await createUserWithEmailAndPassword(
+        auth,
+        userInputData.email,
+        userInputData.password
+      );
 
-	async loginUser(data: UserInput) {
-		try {
-			const userCredential = await signInWithEmailAndPassword(
-				auth,
-				data.email,
-				data.password,
-			);
-			return userCredential.user;
-		} catch (error) {
-			console.error("Error in userRepository.loginUser:", error);
-			throw error;
-		}
-	},
+      const email = userCredential.user.email;
+      if (!email) {
+        throw new Error("メールアドレスが取得できませんでした。");
+      }
+
+      const createdAt =
+        userCredential.user.metadata.creationTime ?? new Date().toISOString();
+
+      const userRef = doc(db, "users", userCredential.user.uid);
+
+      let iconImgUrl = null;
+      if (userInputData.iconImg) {
+        const storageRef = ref(storage, `userIcons/${userCredential.user.uid}`);
+        const iconImgSnapshot = await uploadString(
+          storageRef,
+          userInputData.iconImg,
+          "data_url"
+        );
+        iconImgUrl = await getDownloadURL(iconImgSnapshot.ref);
+      }
+      await setDoc(userRef, {
+        email: userInputData.email,
+        userName: userInputData.userName,
+        iconImg: iconImgUrl,
+        createdAt: userCredential.user.metadata.creationTime,
+      });
+      return {
+        uid: userCredential.user.uid,
+        email: email,
+        userName: userInputData.userName,
+        createdAt: createdAt,
+        iconImg: iconImgUrl,
+      };
+    } catch (error) {
+      console.error("SignUp failed:", error);
+      return Promise.reject(error);
+    }
+  },
+
+  async loginUser(data: UserInput) {
+    try {
+      const userCredential = await signInWithEmailAndPassword(
+        auth,
+        data.email,
+        data.password
+      );
+      return userCredential.user;
+    } catch (error) {
+      console.error("Error in userRepository.loginUser:", error);
+      throw error;
+    }
+  },
 };

--- a/services/userService.ts
+++ b/services/userService.ts
@@ -1,46 +1,51 @@
 import { userRepository } from "@/repositories/userRepository";
-import type { UserInput, User } from "@/types/userTypes";
+import type { User, NewUserInput, LoginUserInput } from "@/types/userTypes";
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import { FirebaseError } from "firebase/app";
 
 export const signUpUser = createAsyncThunk<
   User,
-  UserInput,
+  NewUserInput,
   { rejectValue: string }
->("users/signUpUser", async (userInputData: UserInput, { rejectWithValue }) => {
-  try {
-    const newUser = await userRepository.signUpUser(userInputData);
+>(
+  "users/signUpUser",
+  async (userInputData: NewUserInput, { rejectWithValue }) => {
+    try {
+      const newUser = await userRepository.signUpUser(userInputData);
 
-    return {
-      uid: newUser.uid,
-      email: newUser.email,
-      userName: newUser.userName,
-      iconImg: newUser.iconImg,
-      createdAt: newUser.createdAt,
-    };
-  } catch (error) {
-    if (error instanceof FirebaseError) {
-      switch (error.code) {
-        case "auth/email-already-in-use":
-          return rejectWithValue("このメールアドレスは既に使用されています。");
-        case "auth/invalid-email":
-          return rejectWithValue("無効なメールアドレスです。");
-        default:
-          return rejectWithValue("新規登録に失敗しました。");
+      return {
+        uid: newUser.uid,
+        email: newUser.email,
+        userName: newUser.userName,
+        iconImg: newUser.iconImg,
+        createdAt: newUser.createdAt,
+      };
+    } catch (error) {
+      if (error instanceof FirebaseError) {
+        switch (error.code) {
+          case "auth/email-already-in-use":
+            return rejectWithValue(
+              "このメールアドレスは既に使用されています。"
+            );
+          case "auth/invalid-email":
+            return rejectWithValue("無効なメールアドレスです。");
+          default:
+            return rejectWithValue("新規登録に失敗しました。");
+        }
       }
+      return rejectWithValue("新規登録に失敗しました。");
     }
-    return rejectWithValue("新規登録に失敗しました。");
   }
-});
+);
 
 export const loginUser = createAsyncThunk(
   "users/loginUser",
-  async (data: UserInput, { rejectWithValue }) => {
+  async (data: LoginUserInput, { rejectWithValue }) => {
     try {
       const user = await userRepository.loginUser(data);
       return {
         uid: user.uid,
-        email: user.email,
+        email: user.email as string,
       };
     } catch (error) {
       if (error instanceof FirebaseError) {

--- a/services/userService.ts
+++ b/services/userService.ts
@@ -1,5 +1,5 @@
 import { userRepository } from "@/repositories/userRepository";
-import type { UserInput, User } from "@/types/type";
+import type { UserInput, User } from "@/types/userTypes";
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import { FirebaseError } from "firebase/app";
 
@@ -7,12 +7,16 @@ export const signUpUser = createAsyncThunk<
   User,
   UserInput,
   { rejectValue: string }
->("users/signUpUser", async (data: UserInput, { rejectWithValue }) => {
+>("users/signUpUser", async (userInputData: UserInput, { rejectWithValue }) => {
   try {
-    const newUser = await userRepository.signUpUser(data);
+    const newUser = await userRepository.signUpUser(userInputData);
+
     return {
       uid: newUser.uid,
       email: newUser.email,
+      userName: newUser.userName,
+      iconImg: newUser.iconImg,
+      createdAt: newUser.createdAt,
     };
   } catch (error) {
     if (error instanceof FirebaseError) {

--- a/types/type.ts
+++ b/types/type.ts
@@ -41,13 +41,3 @@ export interface AlbumsProps {
   albums: Album[];
   basePath: string;
 }
-
-export interface User {
-  email: string | null;
-  uid: string | null;
-}
-
-export interface UserInput {
-  email: string;
-  password: string;
-}

--- a/types/userTypes.ts
+++ b/types/userTypes.ts
@@ -1,0 +1,14 @@
+export interface User {
+  email: string;
+  uid: string;
+  userName: string;
+  iconImg: string | null;
+  createdAt: string;
+}
+
+export interface UserInput {
+  email: string;
+  password: string;
+  userName: string;
+  iconImg: string | null;
+}

--- a/types/userTypes.ts
+++ b/types/userTypes.ts
@@ -6,9 +6,19 @@ export interface User {
   createdAt: string;
 }
 
-export interface UserInput {
+export interface LoginUser {
+  email: string;
+  uid: string;
+
+}
+export interface NewUserInput {
   email: string;
   password: string;
   userName: string;
   iconImg: string | null;
+}
+
+export interface LoginUserInput {
+  email: string;
+  password: string;
 }


### PR DESCRIPTION
[今回実装したIssueチケット]
新規登録のパスワードを二重チェックする入力フォーム追加#11
Cloud Firestoreのusersにニックネーム/プロフィール写真/アカウント作成日を追加#30
ユーザーデータ（ユーザーネーム/プロフィール画像）をグローバル管理する#6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

- **新機能**
  - サインアップフォームに新しいユーザー入力フィールドを追加
    - ユーザー名の入力
    - プロファイル画像のアップロード
  - パスワードバリデーションを強化し、正規表現を使用したチェックを追加

- **バグ修正**
  - パスワード確認フィールドを追加し、入力の一致を確認
  - エラーメッセージを具体化し、バリデーション失敗時の表示を改善

- **その他の変更**
  - 画像圧縮機能を追加
  - ユーザータイプの定義を更新
  - CSSのインデントを統一し、新しいスタイルクラスを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->